### PR TITLE
get new auth token after auth expiration

### DIFF
--- a/Assets/Scripts/api/TranslationApi.cs
+++ b/Assets/Scripts/api/TranslationApi.cs
@@ -77,8 +77,6 @@ public static class TranslationApi
 
         string body = JsonUtility.ToJson(user);
 
-        Debug.Log(body);
-
         const string contentType = "application/json";
 
         using (UnityWebRequest webRequest = UnityWebRequest.Post(url, body, contentType))


### PR DESCRIPTION
With this PR, if the auth token expires (after 300 seconds) and we thus can't publish a message or fetch an image from cache, we now request a new auth token to successfully publish the message or fetch the image from cache.

Notes:
- This follows from similar web client logic here: https://github.com/momentohq/moderated-chat/blob/e7e24ab570d90789180bc07b60d0b4128c9f99f7/frontend/src/utils/momento-web.ts#L113-L119
- Just in case you're wondering, it appears that [`UnityWebRequest.Post`](https://docs.unity3d.com/ScriptReference/Networking.UnityWebRequest.Post.html) can only be called from the main UI thread, so that's why there's this `invokeGetAuthToken` business going on in this PR.