### PR TITLE
Feature/jpg compression

### DIFF
--- a/Assets/Scripts/ModeratedChat.cs
+++ b/Assets/Scripts/ModeratedChat.cs
@@ -442,7 +442,7 @@ public class ModeratedChat : MonoBehaviour
             };
             string[] paths = StandaloneFileBrowser.OpenFilePanel("Open File", "", extensions, false);
 
-            if (paths.Length == 0)
+            if (paths.Length == 0 || paths[0] == "")
             {
                 Debug.Log("No image selected");
                 return;

--- a/Assets/StandaloneFileBrowser/LICENSE.txt
+++ b/Assets/StandaloneFileBrowser/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Gökhan Gökçe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Assets/StandaloneFileBrowser/LICENSE.txt.meta
+++ b/Assets/StandaloneFileBrowser/LICENSE.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7ad72b2dda89841499619b0a8cbd3bea
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -157,7 +157,7 @@ PlayerSettings:
   androidMaxAspectRatio: 2.1
   applicationIdentifier:
     Android: com.MomentoInc.momentounitydemo
-    Standalone: com.Momento--Inc..momento-unity-demo
+    Standalone: com.Momento--Inc.momento-unity-demo
   buildNumber:
     Standalone: 0
     VisionOS: 0

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -12,7 +12,7 @@ PlayerSettings:
   targetDevice: 2
   useOnDemandResources: 0
   accelerometerFrequency: 60
-  companyName: Momento, Inc.
+  companyName: Momento, Inc
   productName: momento-unity-demo
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
@@ -156,6 +156,7 @@ PlayerSettings:
   androidSupportedAspectRatio: 1
   androidMaxAspectRatio: 2.1
   applicationIdentifier:
+    Android: com.MomentoInc.momentounitydemo
     Standalone: com.Momento--Inc..momento-unity-demo
   buildNumber:
     Standalone: 0
@@ -278,7 +279,99 @@ PlayerSettings:
   AndroidValidateAppBundleSize: 1
   AndroidAppBundleSizeToValidate: 150
   m_BuildTargetIcons: []
-  m_BuildTargetPlatformIcons: []
+  m_BuildTargetPlatformIcons:
+  - m_BuildTarget: Android
+    m_Icons:
+    - m_Textures: []
+      m_Width: 432
+      m_Height: 432
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 324
+      m_Height: 324
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 216
+      m_Height: 216
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 162
+      m_Height: 162
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 108
+      m_Height: 108
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 81
+      m_Height: 81
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 192
+      m_Height: 192
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 144
+      m_Height: 144
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 96
+      m_Height: 96
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 72
+      m_Height: 72
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 48
+      m_Height: 48
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 36
+      m_Height: 36
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 192
+      m_Height: 192
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 144
+      m_Height: 144
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 96
+      m_Height: 96
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 72
+      m_Height: 72
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 48
+      m_Height: 48
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 36
+      m_Height: 36
+      m_Kind: 0
+      m_SubKind: 
   m_BuildTargetBatching:
   - m_BuildTarget: Standalone
     m_StaticBatching: 1
@@ -747,7 +840,7 @@ PlayerSettings:
   embeddedLinuxEnableGamepadInput: 1
   hmiLogStartupTiming: 0
   hmiCpuConfiguration: 
-  apiCompatibilityLevel: 3
+  apiCompatibilityLevel: 6
   activeInputHandler: 0
   windowsGamepadBackendHint: 0
   cloudProjectId: 


### PR DESCRIPTION
Changes:
- Switch to using Unity's built-in JPG compression to make it usable across more platforms (the [previous approach was only usable on Windows](https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only)); this also allows us to switch the [Unity .NET profile](https://docs.unity3d.com/Manual/dotnetProfileSupport.html) back to .NET Standard from .NET Framework
- Bug fix for cancelling image file picker
- Add missing license for the [UnityStandaloneFileBrowser](https://github.com/gkngkc/UnityStandaloneFileBrowser)

Tested on a MacBook Air running macOS High Sierra:

https://github.com/momentohq/momento-unity-demo/assets/276325/242cb2e9-aa1a-47ab-9247-02302ed2a720

Also tested build on Android and found two issues:
- UI is too small on my Android phone
- As expected, the [UnityStandaloneFileBrowser](https://github.com/gkngkc/UnityStandaloneFileBrowser) doesn't work
