### PR TITLE
Image resizing and cleanup

### DIFF
--- a/Assets/Scenes/MomentoTopicsDemo-ModeratedChat.unity
+++ b/Assets/Scenes/MomentoTopicsDemo-ModeratedChat.unity
@@ -2720,6 +2720,7 @@ MonoBehaviour:
   ChatMessagePrefab: {fileID: 2233962760622741968, guid: d5cc041f1f967ac469c258d05b7c566f, type: 3}
   ImageMessagePrefab: {fileID: 6909446837499291169, guid: 8c2cb1959bbed844da04e5d8567b2fb5, type: 3}
   loadingCircle: {fileID: 278798950}
+  errorCanvas: {fileID: 1901792433}
 --- !u!1 &986823300
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/ModeratedChat.cs
+++ b/Assets/Scripts/ModeratedChat.cs
@@ -101,14 +101,14 @@ public class ModeratedChat : MonoBehaviour
         };
     }
 
-    Color GetUsernameColor(string username)
+    Color GetUsernameColor(string userID)
     {
-        if (!usernameColorMap.ContainsKey(username))
+        if (!usernameColorMap.ContainsKey(userID))
         {
             // https://stackoverflow.com/a/24031467
             using (System.Security.Cryptography.MD5 md5 = System.Security.Cryptography.MD5.Create())
             {
-                byte[] inputBytes = System.Text.Encoding.ASCII.GetBytes(username);
+                byte[] inputBytes = System.Text.Encoding.ASCII.GetBytes(userID);
                 byte[] hashBytes = md5.ComputeHash(inputBytes);
                 System.Text.StringBuilder sb = new System.Text.StringBuilder();
                 for (int i = 0; i < hashBytes.Length; i++)
@@ -118,10 +118,10 @@ public class ModeratedChat : MonoBehaviour
                 string hash = sb.ToString();
                 int colorIndex = Convert.ToInt32(hash.Substring(0, 1), 16) % colors.Length;
 
-                usernameColorMap[username] = unityColors[colorIndex];
+                usernameColorMap[userID] = unityColors[colorIndex];
             }
         }
-        return usernameColorMap[username];
+        return usernameColorMap[userID];
     }
 
     Transform CreateChatMessageContainer(ChatMessageEvent chatMessage, bool imagePrefab = false)
@@ -129,8 +129,6 @@ public class ModeratedChat : MonoBehaviour
         Transform chatMessageContainer = GameObject.Instantiate(
             imagePrefab ? ImageMessagePrefab : ChatMessagePrefab).transform;
 
-        // TODO: maybe username should be passed in, but the JavaScript version passes
-        // in the id, so let's match that for now...
         Color color = GetUsernameColor(chatMessage.user.id);
 
         UnityEngine.UI.Image userBubbleImage = chatMessageContainer.GetChild(0).GetComponent<UnityEngine.UI.Image>();

--- a/Assets/Scripts/api/MomentoWebApi.cs
+++ b/Assets/Scripts/api/MomentoWebApi.cs
@@ -231,7 +231,7 @@ public static class MomentoWebApi
         await Publish(sourceLanguage, JsonUtility.ToJson(pme));
     }
 
-    public static async Task SendImageMessage(string base64Image, string sourceLanguage)
+    public static async Task SendImageMessage(string base64Image, string sourceLanguage, Action<string> onError)
     {
         string imageId = "image-" + Guid.NewGuid().ToString();
         ICacheClient cacheClient = await GetCacheClient();
@@ -254,8 +254,12 @@ public static class MomentoWebApi
                 {
                     Debug.Log("refresh of subscription worked, retrying cache image setting now...");
                     _onSubscribed.Invoke();
-                    await SendImageMessage(base64Image, sourceLanguage);
+                    await SendImageMessage(base64Image, sourceLanguage, onError);
                 }, _onItem, _onSubscriptionError, false);
+            }
+            else if ((response as CacheSetResponse.Error).ErrorCode == MomentoErrorCode.LIMIT_EXCEEDED_ERROR)
+            {
+                onError.Invoke("Image file too big. Please try a smaller image.");
             }
         }
     }

--- a/Assets/Scripts/api/MomentoWebApi.cs
+++ b/Assets/Scripts/api/MomentoWebApi.cs
@@ -25,6 +25,10 @@ public static class MomentoWebApi
     public static ICredentialProvider authProvider = null;
     public static User user = null;
 
+    private const int maxRetries = 5;
+    private static int nRetries = 0;
+    private static bool tryToResubscribe = false;
+
     public static void Dispose()
     {
         cts?.Cancel();
@@ -78,12 +82,24 @@ public static class MomentoWebApi
     }
 
     public static async Task SubscribeToTopic(
-        string languageCode, 
+        string languageCode,
         Action onSubscribed,
         Action<TopicMessage> onItem,
         Action<TopicSubscribeResponse.Error> onSubscriptionError,
-        bool cacheActionsAndLanguage = true
+        bool cacheActionsAndLanguage = true,
+        bool retry = false
     ) {
+
+        if (retry)
+        {
+            if (nRetries >= maxRetries)
+            {
+                Debug.LogError("Reached maximum number of resubscribe tries, stopping...");
+                return;
+            }
+            nRetries++;
+        }
+
         string topicName = "chat-" + languageCode;
 
         // cache actions for reconnects
@@ -130,7 +146,8 @@ public static class MomentoWebApi
                                     case TopicMessage.Error error:
                                         Debug.LogError(String.Format("Received error message from topic: {0}",
                                             error.Message));
-                                        cts.Cancel(); // TODO restart subscription?
+                                        cts.Cancel();
+                                        tryToResubscribe = true;
                                         break;
                                 }
                             }
@@ -144,8 +161,6 @@ public static class MomentoWebApi
                         break;
                     case TopicSubscribeResponse.Error error:
                         Debug.LogError(String.Format("Error subscribing to a topic: {0}", error.Message));
-                        //textAreaString += "Error trying to connect to chat, cancelling...";
-                        //this.error = true;
                         onSubscriptionError.Invoke(error);
                         cts.Cancel();
                         break;
@@ -157,6 +172,14 @@ public static class MomentoWebApi
             Debug.Log("Topic subscription cancelled");
             client?.Dispose();
             topicClient?.Dispose();
+
+            if (tryToResubscribe)
+            {
+                tryToResubscribe = false;
+
+                await SubscribeToTopic(_languageCode, _onSubscribed, 
+                    _onItem, _onSubscriptionError, false, true);
+            }
         }
     }
 
@@ -179,14 +202,14 @@ public static class MomentoWebApi
 
             if ((response as CacheGetResponse.Error).ErrorCode == MomentoErrorCode.AUTHENTICATION_ERROR)
             {
-                // TODO: might want to put a limit on out many retries we do here...
                 Debug.LogError("token has likely expired, going to refresh subscription and retry fetching image from cache");
                 await SubscribeToTopic(_languageCode, async () =>
-                {
-                    Debug.Log("refresh of subscription worked, retrying cache fetch now...");
-                    _onSubscribed.Invoke();
-                    await GetImageMessage(imageId, onHit);
-                }, _onItem, _onSubscriptionError, false);
+                    {
+                        Debug.Log("refresh of subscription worked, retrying cache fetch now...");
+                        _onSubscribed.Invoke();
+                        await GetImageMessage(imageId, onHit);
+                    }, _onItem, _onSubscriptionError, false, true
+                );
             }
         }
     }
@@ -204,14 +227,14 @@ public static class MomentoWebApi
                 Debug.LogError(String.Format("Error publishing a message to the topic: {0}", error.Message));
                 if (error.ErrorCode == Momento.Sdk.Exceptions.MomentoErrorCode.AUTHENTICATION_ERROR)
                 {
-                    // TODO: might want to put a limit on out many retries we do here...
                     Debug.LogError("token has likely expired, going to refresh subscription and retry publish");
                     await SubscribeToTopic(targetLanguage, async () =>
-                    {
-                        Debug.Log("refresh of subscription worked, retrying publish now...");
-                        _onSubscribed.Invoke();
-                        await Publish(targetLanguage, message);
-                    }, _onItem, _onSubscriptionError, false);
+                        {
+                            Debug.Log("refresh of subscription worked, retrying publish now...");
+                            _onSubscribed.Invoke();
+                            await Publish(targetLanguage, message);
+                        }, _onItem, _onSubscriptionError, false, true
+                    );
                 }
                 break;
         }
@@ -248,14 +271,14 @@ public static class MomentoWebApi
 
             if ((response as CacheSetResponse.Error).ErrorCode == MomentoErrorCode.AUTHENTICATION_ERROR)
             {
-                // TODO: might want to put a limit on out many retries we do here...
                 Debug.LogError("token has likely expired, going to refresh subscription and retry setting image in cache");
                 await SubscribeToTopic(_languageCode, async () =>
-                {
-                    Debug.Log("refresh of subscription worked, retrying cache image setting now...");
-                    _onSubscribed.Invoke();
-                    await SendImageMessage(base64Image, sourceLanguage, onError);
-                }, _onItem, _onSubscriptionError, false);
+                    {
+                        Debug.Log("refresh of subscription worked, retrying cache image setting now...");
+                        _onSubscribed.Invoke();
+                        await SendImageMessage(base64Image, sourceLanguage, onError);
+                    }, _onItem, _onSubscriptionError, false, true
+                );
             }
             else if ((response as CacheSetResponse.Error).ErrorCode == MomentoErrorCode.LIMIT_EXCEEDED_ERROR)
             {

--- a/Assets/Scripts/api/TranslationApi.cs
+++ b/Assets/Scripts/api/TranslationApi.cs
@@ -115,7 +115,7 @@ public static class TranslationApi
 
             if (webRequest.result == UnityWebRequest.Result.Success)
             {
-                Debug.Log("Got result:" + webRequest.downloadHandler.text);
+                Debug.Log("Got result (data length " + webRequest.downloadHandler.data.Length + "): " + webRequest.downloadHandler.text);
 
                 onResponse.Invoke(JsonUtility.FromJson<LatestChats>(webRequest.downloadHandler.text));
             }


### PR DESCRIPTION
Mostly various cleanup in this PR:
- resizes the image to be at most 800 pixels in a dimension while preserving aspect ratio
- will try to compress the image further if it's still too big in size
- add error canvas to show error messages to the user
- shows specific error if trying to set an image to the Cache gives a `LIMIT_EXCEEDED_ERROR` response
- limits retries of resubscribing
- tries to resubscribe on some errors